### PR TITLE
meta name generator for invokable; other tweaks

### DIFF
--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -67,18 +67,18 @@ private:
     DECLARE_PRIVATE_PTR(MetaLibraryPrivate)
 };
 
-/// Checks whether the string passed as argument is a valid metaname. A metaname can only contain
+/// Checks whether the string passed as argument is a valid meta-name. A meta-name can only contain
 /// numeric and alphanumeric characters, dots, columns, dashes and underscores.
 /// \param text The string to check.
-/// \return If the string is a valid metaname, returns \e true, otherwise \e false.
+/// \return If the string is a valid meta-name, returns \e true, otherwise \e false.
 META_API bool isValidMetaName(std::string_view text);
 
-/// Ensures the string passed as argument is a valid metaname. A metaname can only contain
+/// Ensures the string passed as argument is a valid meta-name. A meta-name can only contain
 /// numeric and alphanumeric characters, dots, columns, dashes and underscores. Any invalid character
 /// is replaces with the hint character, which is also checked against validity.
 /// \param name The string to check.
 /// \param hint The character to replace every invalid character occurrence in the name
-/// \return If the string is a valid metaname, returns \e true, otherwise \e false.
+/// \return If the string is a valid meta-name, returns \e true, otherwise \e false.
 META_API std::string ensureValidMetaName(std::string name, char hint = '.');
 
 } // namespace meta

--- a/include/meta/meta.hpp
+++ b/include/meta/meta.hpp
@@ -73,6 +73,14 @@ private:
 /// \return If the string is a valid metaname, returns \e true, otherwise \e false.
 META_API bool isValidMetaName(std::string_view text);
 
+/// Ensures the string passed as argument is a valid metaname. A metaname can only contain
+/// numeric and alphanumeric characters, dots, columns, dashes and underscores. Any invalid character
+/// is replaces with the hint character, which is also checked against validity.
+/// \param name The string to check.
+/// \param hint The character to replace every invalid character occurrence in the name
+/// \return If the string is a valid metaname, returns \e true, otherwise \e false.
+META_API std::string ensureValidMetaName(std::string name, char hint = '.');
+
 } // namespace meta
 
 #endif // META_HPP

--- a/include/meta/metadata/factory.hpp
+++ b/include/meta/metadata/factory.hpp
@@ -46,21 +46,16 @@ public:
     /// \return If the meta class gets registered with success, returns \e true, otherwise \e false.
     bool registerMetaClass(const MetaClass* metaClass);
 
-    /// Registers a meta class with a metaname. The meta class gets updated with the metaname. The
-    /// registration fails if there is a meta class registered with the metaname, or if the metaname
-    /// is empty or invalid. On failure, an error is logged with the message.
-    /// \param name The metaname with which to register the meta class.
-    /// \param metaClass The meta class to register.
-    /// \return If the meta class gets registered with the metaname with success, returns \e true,
-    ///         otherwise \e false.
-    bool registerMetaClass(std::string_view name, const MetaClass* metaClass);
+    template <class ClassType>
+    bool registerMetaClass()
+    {
+        return registerMetaClass(ClassType::getStaticMetaClass());
+    }
 
-    /// Overrides a meta class registered under a name with an other meta class. The meta class which
-    /// overrides the previous registration is updated with the metaname passed as argument.
-    /// \param name The metaname under which a previous meta class is registered.
+    /// Overrides a meta class registered under the same name as the overriding metaclass.
     /// \param metaClass The meta class which overrides the previously registered meta class.
     /// \return If the meta class gets overridden with success, returns \e true, otherwise \e false.
-    bool overrideMetaClass(std::string_view name, const MetaClass* metaClass);
+    bool overrideMetaClass(const MetaClass* metaClass);
 
     /// Finds a meta class registered under \a className.
     /// \param className The name under which the metaclass is registered.

--- a/include/meta/metadata/factory.hpp
+++ b/include/meta/metadata/factory.hpp
@@ -40,9 +40,9 @@ public:
     /// Factory registry iterator.
     using MetaClassIterator = MetaClassMap::const_iterator;
 
-    /// Registers a meta class.
-    /// \param metaClass The meta class to register.
-    /// \return If the meta class gets registered with success, returns \e true, otherwise \e false.
+    /// Registers a meta-class.
+    /// \param metaClass The meta-class to register.
+    /// \return If the meta-class gets registered with success, returns \e true, otherwise \e false.
     bool registerMetaClass(const MetaClass* metaClass);
 
     template <class ClassType>
@@ -51,29 +51,29 @@ public:
         return registerMetaClass(ClassType::getStaticMetaClass());
     }
 
-    /// Overrides a meta class registered under the same name as the overriding metaclass.
-    /// \param metaClass The meta class which overrides the previously registered meta class.
-    /// \return If the meta class gets overridden with success, returns \e true, otherwise \e false.
+    /// Overrides a meta-class registered under the same name as the overriding metaclass.
+    /// \param metaClass The meta-class which overrides the previously registered meta-class.
+    /// \return If the meta-class gets overridden with success, returns \e true, otherwise \e false.
     bool overrideMetaClass(const MetaClass* metaClass);
 
-    /// Finds a meta class registered under \a className.
+    /// Finds a meta-class registered under \a className.
     /// \param className The name under which the metaclass is registered.
-    /// \return The meta class, or \e nullptr, if no meta class with name was found.
+    /// \return The meta-class, or \e nullptr, if no meta-class with name was found.
     const MetaClass* findMetaClass(std::string_view className) const;
 
-    /// Returns the front of the meta class registry.
+    /// Returns the front of the meta-class registry.
     MetaClassIterator begin() const
     {
         return m_registry.begin();
     }
-    /// Returns the end of the meta class registry.
+    /// Returns the end of the meta-class registry.
     MetaClassIterator end() const
     {
         return m_registry.end();
     }
 
-    /// Creates an instance from the registered meta class of an ObjectType
-    /// \tparam ObjectType The object type whose meta class must be registered.
+    /// Creates an instance from the registered meta-class of an ObjectType
+    /// \tparam ObjectType The object type whose meta-class must be registered.
     /// \param instanceName The name with which to create the instance.
     /// \return On success, returns the instance created, or an invalid shared pointer on failure.
     template <class ObjectType>
@@ -82,8 +82,8 @@ public:
         return std::dynamic_pointer_cast<ObjectType>(create(ObjectType::getStaticMetaClass()->getName(), instanceName));
     }
 
-    /// Creates an instance from the registered meta class identified by the className, with the passed Arguments.
-    /// \param className The name of the meta class.
+    /// Creates an instance from the registered meta-class identified by the className, with the passed Arguments.
+    /// \param className The name of the meta-class.
     /// \param instanceName The name with which to create the instance.
     /// \return On success, returns the instance created, or an invalid shared pointer on failure.
     MetaObjectPtr create(std::string_view className, std::string_view instanceName);

--- a/include/meta/metadata/factory.hpp
+++ b/include/meta/metadata/factory.hpp
@@ -73,19 +73,26 @@ public:
         return m_registry.end();
     }
 
-    /// Creates an instance from the registered meta class of an ObjectType, with the passed Arguments.
+    /// Creates an instance from the registered meta class of an ObjectType
     /// \tparam ObjectType The object type whose meta class must be registered.
     /// \param instanceName The name with which to create the instance.
     /// \return On success, returns the instance created, or an invalid shared pointer on failure.
     template <class ObjectType>
     std::shared_ptr<ObjectType> create(std::string_view instanceName)
     {
-        auto metaClass = findMetaClass(ObjectType::getStaticMetaClass()->getName());
-        if (!metaClass)
-        {
-            return {};
-        }
-        return metaClass->template create<ObjectType>(instanceName);
+        return std::dynamic_pointer_cast<ObjectType>(create(ObjectType::getStaticMetaClass()->getName(), instanceName));
+    }
+
+    /// Creates an instance from the registered meta class identified by the className, with the passed Arguments.
+    /// \param className The name of the meta class.
+    /// \param instanceName The name with which to create the instance.
+    /// \return On success, returns the instance created, or an invalid shared pointer on failure.
+    MetaObjectPtr create(std::string_view className, std::string_view instanceName);
+
+    template <class ObjectType>
+    std::shared_ptr<ObjectType> create(std::string_view className, std::string_view instanceName)
+    {
+        return std::dynamic_pointer_cast<ObjectType>(create(className, instanceName));
     }
 };
 

--- a/include/meta/metadata/factory.hpp
+++ b/include/meta/metadata/factory.hpp
@@ -33,7 +33,6 @@ class MetaClass;
 /// Object factory. Keeps a registry of meta classes of an application.
 class META_API ObjectFactory
 {
-    friend struct ObjectFactoryPrivate;
     using MetaClassMap = std::unordered_map<std::string_view, const MetaClass*>;
     MetaClassMap m_registry;
 

--- a/include/meta/metadata/meta_object.hpp
+++ b/include/meta/metadata/meta_object.hpp
@@ -45,7 +45,7 @@ public:
     {
     };
 
-    /// Returns the dynamic meta class of the meta object.
+    /// Returns the dynamic meta-class of the meta object.
     virtual const MetaClass* getDynamicMetaClass() const
     {
         return getStaticMetaClass();
@@ -74,7 +74,7 @@ protected:
     }
 
 private:
-    /// Holds the meta class which created the object. The value of \e nullptr means the object was
+    /// Holds the meta-class which created the object. The value of \e nullptr means the object was
     /// not created through meta-class.
     MetaClass* m_factory = nullptr;
     /// The meta-name of the meta-object.

--- a/include/meta/metadata/meta_object.hpp
+++ b/include/meta/metadata/meta_object.hpp
@@ -39,11 +39,16 @@ public:
         return m_name;
     }
 
-    META_CLASS("meta.MetaObject", MetaObject)
-    {
-    };
+    /// Returns the static meta class of the meta object.
+    static const MetaClass* getStaticMetaClass();
 
-    static auto create(std::string_view name)
+    /// Returns the dynamic meta class of the meta object.
+    virtual const MetaClass* getDynamicMetaClass() const
+    {
+        return getStaticMetaClass();
+    }
+
+    static MetaObjectPtr create(std::string_view name)
     {
         return MetaObjectPtr(new MetaObject(name));
     }

--- a/include/meta/metadata/meta_object.hpp
+++ b/include/meta/metadata/meta_object.hpp
@@ -28,19 +28,22 @@ namespace meta
 /// The base class of objects whith metadata.
 class META_API MetaObject
 {
+    friend class MetaClass;
+
 public:
     /// Destructor.
     virtual ~MetaObject();
 
-    /// Returns the name of the metaobject.
-    /// \return The name of the metaobject.
+    /// Returns the name of the meta-object.
+    /// \return The name of the meta-object.
     std::string_view getName() const
     {
         return m_name;
     }
 
-    /// Returns the static meta class of the meta object.
-    static const MetaClass* getStaticMetaClass();
+    STATIC_META_CLASS("meta.MetaObject", MetaObject)
+    {
+    };
 
     /// Returns the dynamic meta class of the meta object.
     virtual const MetaClass* getDynamicMetaClass() const
@@ -53,12 +56,28 @@ public:
         return MetaObjectPtr(new MetaObject(name));
     }
 
+    /// Returns the factory meta-class which created the object. By default this is the dynamic meta-class.
+    /// \return The factory meta-class which created the object. If the object was not creasted by
+    ///         a meta-class, returns nullptr;
+    const MetaClass* getFactory() const
+    {
+        return m_factory;
+    }
+
 protected:
-    /// Constructor. Fails if the metaname passed as argument is invalid.
+    /// Constructor. Fails if the meta-name passed as argument is invalid.
     explicit MetaObject(std::string_view metaName);
 
+    /// Second phase initializer of the object.
+    void initialize()
+    {
+    }
+
 private:
-    /// The metaname of the metaobject.
+    /// Holds the meta class which created the object. The value of \e nullptr means the object was
+    /// not created through meta-class.
+    MetaClass* m_factory = nullptr;
+    /// The meta-name of the meta-object.
     std::string m_name;
 };
 

--- a/include/meta/metadata/metaclass.hpp
+++ b/include/meta/metadata/metaclass.hpp
@@ -33,23 +33,23 @@
 namespace meta
 {
 
-/// Defines the metaclass of an associated class. The meta class provides type inspection mechanism
+/// Defines the metaclass of an associated class. The meta-class provides type inspection mechanism
 /// for your classes. You can use the meta information of a class to provide dynamic behavior through
 /// scripting.
 ///
-/// Use META_CLASS() macro in the public body of your class to declare the meta class. The macro declares
-/// methods for both static and dynamic meta class. The name of the meta class identifies the class
+/// Use META_CLASS() macro in the public body of your class to declare the meta-class. The macro declares
+/// methods for both static and dynamic meta-class. The name of the meta-class identifies the class
 /// in interoperability between scripting and native code.
 ///
 /// Use STATIC_META_CLASS() macro in classes which do not derive from MetaObject. These classes only
 /// have static meta data.
 ///
 /// Use AUTO_META_CLASS() macro declare meta classes whose meta name gets generated automatically at
-/// compile time. The name of the meta class is generated from the RTTI name of the type. Use these
-/// macros when you don't need to know the meta class name in your application.
+/// compile time. The name of the meta-class is generated from the RTTI name of the type. Use these
+/// macros when you don't need to know the meta-class name in your application.
 ///
-/// Use META_EXTENSION() macro to add the meta class of object extensions. Use the macro inside the
-/// body of the meta class declaration. Example:
+/// Use META_EXTENSION() macro to add the meta-class of object extensions. Use the macro inside the
+/// body of the meta-class declaration. Example:
 /// \code
 ///
 /// class RunMe : public meta::ObjectExtension
@@ -85,7 +85,7 @@ class META_API MetaClass
     DISABLE_MOVE(MetaClass);
 
 public:
-    /// Container with the meta classes of the object extensions added to a meta class.
+    /// Container with the meta classes of the object extensions added to a meta-class.
     using MetaExtensionContainer = std::unordered_map<std::string_view, const MetaClass*>;
     /// The iterator of the meta extensions.
     using MetaExtensionIterator = MetaExtensionContainer::const_iterator;
@@ -93,7 +93,7 @@ public:
     /// Destructor.
     virtual ~MetaClass() = default;
 
-    /// Creates an object of the class to which the meta class is connected.
+    /// Creates an object of the class to which the meta-class is connected.
     /// \param name The name of the meta object created.
     MetaObjectPtr create(std::string_view name) const;
 
@@ -103,15 +103,15 @@ public:
         return std::dynamic_pointer_cast<T>(MetaClass::create(name));
     }
 
-    /// Returns whether the meta class is sealed.
-    /// \return If the meta class is sealed, returns \e true, otherwise \e false.
+    /// Returns whether the meta-class is sealed.
+    /// \return If the meta-class is sealed, returns \e true, otherwise \e false.
     bool isSealed() const;
 
     /// Returns the name of the metaclass.
     std::string_view getName() const;
 
-    /// Returns whether the class to which the meta class is connected is abstract.
-    /// \return If the class to which the meta class is connected is abstract, returns \e true,
+    /// Returns whether the class to which the meta-class is connected is abstract.
+    /// \return If the class to which the meta-class is connected is abstract, returns \e true,
     ///         otherwise \e false.
     bool isAbstract() const;
 
@@ -148,7 +148,7 @@ public:
     /// \return The visit result.
     VisitResult visit(Visitor visitor) const;
 
-    /// Visits the super meta-classes of a meta class.
+    /// Visits the super meta-classes of a meta-class.
     /// \param visitor The visitor function.
     /// \return The visit result.
     VisitResult visitSuper(Visitor visitor) const;
@@ -156,14 +156,14 @@ public:
 
     /// \name Meta extensions
     /// \{
-    /// Meta extensions are meta classes of object extensions you can add to the meta class of an Object.
-    /// When you create an instance of an object through a meta class, Meta automatically attaches
+    /// Meta extensions are meta classes of object extensions you can add to the meta-class of an Object.
+    /// When you create an instance of an object through a meta-class, Meta automatically attaches
     /// the object extensions to the created instance.
 
-    /// Adds the meta class of an object extension to this meta class. The method fails if either this
-    /// or the meta class of the object extension is invalid, the meta class is not a meta class of
-    /// an object extension, or there is an object extension meta class registered with the same name.
-    /// \param extensionMeta The meta class of the object extension to add.
+    /// Adds the meta-class of an object extension to this meta-class. The method fails if either this
+    /// or the meta-class of the object extension is invalid, the meta-class is not a meta-class of
+    /// an object extension, or there is an object extension meta-class registered with the same name.
+    /// \param extensionMeta The meta-class of the object extension to add.
     void addMetaExtension(const MetaClass* extensionMeta);
 
     template <class ClassType>
@@ -172,22 +172,23 @@ public:
         addMetaExtension(ClassType::getStaticMetaClass());
     }
 
-    /// Tries to add the meta class of a registered object extension to this meta class. The meta class
+    /// Tries to add the meta-class of a registered object extension to this meta-class. The meta-class
     /// must be registered to Meta library under the meta-name passed as argument.
-    /// \param metaName The meta-name of teh meta class to register as extension.
-    /// \return If the meta class of the object extension was registered with success, returns \e true,
+    /// \param metaName The meta-name of teh meta-class to register as extension.
+    /// \return If the meta-class of the object extension was registered with success, returns \e true,
     ///         otherwise \e false.
     bool tryAddExtension(std::string_view metaName);
 
-    /// Finds the object extension meta class registered under a given name.
-    /// \param name The meta-name of the object extension meta class to find.
-    /// \return On success returns the meta class of the object extension, or \e nullptr on failure.
+    /// Tries to find the object extension meta-class registered under a given name. The look-up includes
+    /// the super meta-classes too.
+    /// \param name The meta-name of the object extension meta-class to find.
+    /// \return On success returns the meta-class of the object extension, or \e nullptr on failure.
     const MetaClass* findMetaExtension(std::string_view name) const;
 
-    /// Returns the begin iterator of the object extensions meta class register.
+    /// Returns the begin iterator of the object extensions meta-class register.
     MetaExtensionIterator beginExtensions() const;
 
-    /// Returns the end iterator of the object extensions meta class register.
+    /// Returns the end iterator of the object extensions meta-class register.
     MetaExtensionIterator endExtensions() const;
     /// \}
 
@@ -197,7 +198,7 @@ protected:
     {
         /// The container with the meta extensions.
         MetaExtensionContainer extensions;
-        /// The name of the meta class.
+        /// The name of the meta-class.
         const std::string name;
         /// Whether the metaclass is sealed.
         bool sealed = false;
@@ -243,7 +244,7 @@ struct META_API Registrars
         explicit Extension(Registrars& self, const MetaClass* extension);
     };
 
-    /// Applies the registrars on the meta class.
+    /// Applies the registrars on the meta-class.
     void apply(MetaClass& metaClass);
 
 private:
@@ -260,7 +261,7 @@ private:
 /// Defines the static metadata of a class. The first argument is the name of the metaclass, followed
 /// by the class for which you declare the meta data. The rest of the arguments should refer to the
 /// base classes, preferrably in the order of the derivate definition. The metadata has no dynamic
-/// meta class. Use this macro to declare the static meta class of both classes which derive from
+/// meta-class. Use this macro to declare the static meta-class of both classes which derive from
 /// MetaObject and for those which don't.
 #define STATIC_META_CLASS(ClassName, ...)                                       \
 struct StaticMetaClass;                                                         \

--- a/include/meta/metadata/metaclass_impl.hpp
+++ b/include/meta/metadata/metaclass_impl.hpp
@@ -57,7 +57,7 @@ protected:
         {
             auto result = VisitResult::Continue;
 
-            auto predicate = [&visitor, &result](auto metaClass)
+            auto predicate = [&visitor, &result](const MetaClass* metaClass)
             {
                 if (result == VisitResult::Abort)
                 {

--- a/include/meta/metadata/metaclass_impl.hpp
+++ b/include/meta/metadata/metaclass_impl.hpp
@@ -37,7 +37,6 @@ protected:
     {
         explicit MetaClassDescriptor()
         {
-            sealed = true;
         }
 
         MetaObjectPtr create(std::string_view name) const override
@@ -113,6 +112,7 @@ public:
     explicit MetaClassImpl() :
         MetaClass(std::make_unique<MetaClassDescriptor>())
     {
+        m_descriptor->sealed = true;
     }
 };
 

--- a/include/meta/metadata/metaclass_impl.hpp
+++ b/include/meta/metadata/metaclass_impl.hpp
@@ -25,17 +25,18 @@ namespace meta
 namespace detail
 {
 
-template <class DeclaredClass, class... SuperClasses>
+template <class MetaRegistrars, class DeclaredClass, class... SuperClasses>
 class META_TEMPLATE_API MetaClassImpl : public MetaClass
 {
-    using SelfType = MetaClassImpl<DeclaredClass, SuperClasses...>;
+    using SelfType = MetaClassImpl<MetaRegistrars, DeclaredClass, SuperClasses...>;
 
 protected:
     static constexpr auto arity = sizeof... (SuperClasses);
 
     struct META_API MetaClassDescriptor : DescriptorInterface
     {
-        explicit MetaClassDescriptor()
+        explicit MetaClassDescriptor(std::string_view metaClassName) :
+            DescriptorInterface(metaClassName)
         {
         }
 
@@ -109,10 +110,13 @@ protected:
     };
 
 public:
-    explicit MetaClassImpl() :
-        MetaClass(std::make_unique<MetaClassDescriptor>())
+    explicit MetaClassImpl(std::string_view metaClassName) :
+        MetaClass(std::make_unique<MetaClassDescriptor>(metaClassName))
     {
-        m_descriptor->sealed = true;
+        static_assert(std::is_base_of_v<Registrars, MetaRegistrars>, "MetaRegistrars template argument must derive from meta::Registrars.");
+        MetaRegistrars registrars;
+        registrars.apply(*this);
+        this->m_descriptor->sealed = true;
     }
 };
 

--- a/include/meta/object.hpp
+++ b/include/meta/object.hpp
@@ -45,7 +45,6 @@ public:
     /// The metadata of a meta object.
     META_CLASS("meta.Object", Object, MetaObject)
     {
-        DYNAMIC_META_CLASS();
     };
 
     /// Adds an extension to the object. The object takes ownership over the extension. The method
@@ -78,6 +77,9 @@ public:
 protected:
     /// Constructor.
     explicit Object(std::string_view name);
+
+    /// Second phase initializer.
+    void initialize();
 
 private:
     using ExtensionsMap = std::unordered_map<std::string_view, ObjectExtensionPtr>;

--- a/include/meta/object.hpp
+++ b/include/meta/object.hpp
@@ -32,7 +32,7 @@
 namespace meta
 {
 
-/// The base class of any object that defines a meta class.
+/// The base class of any object that defines a meta-class.
 class META_API Object : public MetaObject, public std::enable_shared_from_this<Object>
 {
 public:

--- a/include/meta/object_extensions/invokable.hpp
+++ b/include/meta/object_extensions/invokable.hpp
@@ -44,7 +44,7 @@ namespace meta
 ///
 /// // You can register the LambdaExtension to the factory.
 /// meta::Library()::instance()->factory()->registerMetaClass<LambdaExtension>();
-/// // You can also add the LambdaExtension to the meta class of the Object.
+/// // You can also add the LambdaExtension to the meta-class of the Object.
 /// Object::getDynamicMetaClass()->addMetaExtension<LambdaExtension>();
 /// \endcode
 /// To call invokable extensions on an Object, use the meta::invoke() function.
@@ -152,7 +152,7 @@ Argument Invokable<Function, function>::runOverride(const PackagedArguments& arg
 }
 
 /// Use this macro to declare a static name for your invokable function. The invokable object gets
-/// created with the meta name of the meta class.
+/// created with the meta name of the meta-class.
 /// \param InvokableClass The object extension class to define for the invokable function.
 /// \param InvokableName The static name of the invokable.
 /// \param Funtion The address of the function, method or the lambda.

--- a/include/meta/object_extensions/invokable.hpp
+++ b/include/meta/object_extensions/invokable.hpp
@@ -156,21 +156,21 @@ Argument Invokable<Function, function>::runOverride(const PackagedArguments& arg
 /// \param InvokableClass The object extension class to define for the invokable function.
 /// \param InvokableName The static name of the invokable.
 /// \param Funtion The address of the function, method or the lambda.
-#define DECLARE_INVOKABLE(InvokableClass, InvokableName, Function)                  \
-struct META_API InvokableClass : public meta::Invokable<decltype(Function), Function>        \
-{                                                                                   \
-    using Base = meta::Invokable<decltype(Function), Function>;                     \
-    META_CLASS(InvokableName, InvokableClass, Base)                                 \
-    {                                                                               \
-    };                                                                              \
-    static std::shared_ptr<InvokableClass> create(std::string_view)                 \
-    {                                                                               \
-        return std::make_shared<InvokableClass>(getStaticMetaClass()->getName());   \
-    }                                                                               \
-    explicit InvokableClass(std::string_view name) :                                \
-        Base(name)                                                                  \
-    {                                                                               \
-    }                                                                               \
+#define DECLARE_INVOKABLE(InvokableClass, InvokableName, Function)                      \
+struct META_API InvokableClass : public meta::Invokable<decltype(Function), Function>   \
+{                                                                                       \
+    using Base = meta::Invokable<decltype(Function), Function>;                         \
+    META_CLASS(InvokableName, InvokableClass, Base)                                     \
+    {                                                                                   \
+    };                                                                                  \
+    static std::shared_ptr<InvokableClass> create(std::string_view = std::string_view())\
+    {                                                                                   \
+        return std::make_shared<InvokableClass>(getStaticMetaClass()->getName());       \
+    }                                                                                   \
+    explicit InvokableClass(std::string_view name) :                                    \
+        Base(name)                                                                      \
+    {                                                                                   \
+    }                                                                                   \
 }
 
 #endif // META_INVOKABLE_HPP

--- a/include/meta/object_extensions/invokable.hpp
+++ b/include/meta/object_extensions/invokable.hpp
@@ -30,9 +30,24 @@
 namespace meta
 {
 
-/// %Invokable represents an invokable extension of an Object, which can be applied on an instance
-/// at runtime. To add an invokable to an instance of an Object, call Object::addExtension(). You can
-/// call invokable extensions by calling the meta::invoke() function.
+/// %Invokable represents an object extension to a callable object, which you can apply on an Object
+/// at runtime. To add an invokable to an Object, call Object::addExtension() method.
+///
+/// Invokables have meta names generated from the RTTI type name of the callable object. This makes
+/// the invokation by name inconvenient. To overcome this, Meta provides a macro, which you can use
+/// to provide a static name for your Invokable. An example of how to provide a static name for your
+/// global lambda:
+/// \code
+/// // The global lambda for which to register an invokable extension.
+/// auto globalLambda = [](){};
+/// DECLARE_INVOKABLE(LambdaExtension, "lambda", globalLambda);
+///
+/// // You can register the LambdaExtension to the factory.
+/// meta::Library()::instance()->factory()->registerMetaClass<LambdaExtension>();
+/// // You can also add the LambdaExtension to the meta class of the Object.
+/// Object::getDynamicMetaClass()->addMetaExtension<LambdaExtension>();
+/// \endcode
+/// To call invokable extensions on an Object, use the meta::invoke() function.
 ///
 /// In most cases, the invokable needs to access the instance it extends. To do that, the first argument
 /// of the invokable function should be a pionter to ObjectExtension:
@@ -48,7 +63,7 @@ namespace meta
 ///
 /// The invokable arguments can hold any type, except reference types.
 template <class Function, Function function>
-class Invokable final : public ObjectExtension
+class Invokable : public ObjectExtension
 {
     using SelfType = Invokable<Function, function>;
 
@@ -56,14 +71,15 @@ protected:
     /// Repackages the arguments, appending the owning object and itself, when required.
     PackagedArguments repackageArguments(const PackagedArguments& arguments);
     /// Overrides ObjectExtension::Descriptor::runOverride().
-    Argument runOverride(const PackagedArguments& arguments);
+    Argument runOverride(const PackagedArguments& arguments) final;
 
     /// Constructor.
     explicit Invokable(std::string_view name);
 
 public:
-    STUB_META_CLASS(SelfType, ObjectExtension)
+    AUTO_META_CLASS(SelfType, ObjectExtension)
     {
+        MetaClass::MetaName _n{*this, Argument::Type(typeid(Function)).getName()};
     };
 
     /// Creates an instance of the Invokable type.
@@ -134,6 +150,28 @@ Argument Invokable<Function, function>::runOverride(const PackagedArguments& arg
     }
 }
 
+}
+
+/// Use this macro to declare a static name for your invokable function. The invokable object gets
+/// created with the meta name of the meta class.
+/// \param InvokableClass The object extension class to define for the invokable function.
+/// \param InvokableName The static name of the invokable.
+/// \param Funtion The address of the function, method or the lambda.
+#define DECLARE_INVOKABLE(InvokableClass, InvokableName, Function)                  \
+struct InvokableClass : public meta::Invokable<decltype(Function), Function>        \
+{                                                                                   \
+    using Base = meta::Invokable<decltype(Function), Function>;                     \
+    META_CLASS(InvokableName, InvokableClass, Base)                                 \
+    {                                                                               \
+    };                                                                              \
+    static std::shared_ptr<InvokableClass> create(std::string_view)                 \
+    {                                                                               \
+        return std::make_shared<InvokableClass>(getStaticMetaClass()->getName());   \
+    }                                                                               \
+    explicit InvokableClass(std::string_view name) :                                \
+        Base(name)                                                                  \
+    {                                                                               \
+    }                                                                               \
 }
 
 #endif // META_INVOKABLE_HPP

--- a/include/meta/object_extensions/invokable.hpp
+++ b/include/meta/object_extensions/invokable.hpp
@@ -77,9 +77,8 @@ protected:
     explicit Invokable(std::string_view name);
 
 public:
-    AUTO_META_CLASS(SelfType, ObjectExtension)
+    AUTO_META_CLASS(Function, SelfType, ObjectExtension)
     {
-        MetaClass::MetaName _n{*this, Argument::Type(typeid(Function)).getName()};
     };
 
     /// Creates an instance of the Invokable type.
@@ -158,7 +157,7 @@ Argument Invokable<Function, function>::runOverride(const PackagedArguments& arg
 /// \param InvokableName The static name of the invokable.
 /// \param Funtion The address of the function, method or the lambda.
 #define DECLARE_INVOKABLE(InvokableClass, InvokableName, Function)                  \
-struct InvokableClass : public meta::Invokable<decltype(Function), Function>        \
+struct META_API InvokableClass : public meta::Invokable<decltype(Function), Function>        \
 {                                                                                   \
     using Base = meta::Invokable<decltype(Function), Function>;                     \
     META_CLASS(InvokableName, InvokableClass, Base)                                 \

--- a/include/meta/object_extensions/object_extension.hpp
+++ b/include/meta/object_extensions/object_extension.hpp
@@ -37,13 +37,13 @@ namespace meta
 /// at a time. You can move an object extension from an Object instance to an other by removing the
 /// object extension from the source instance before adding it to the destination instance.
 ///
-/// You can add object extensions to a meta class of an Object by adding its meta class to the meta
+/// You can add object extensions to a meta-class of an Object by adding its meta-class to the meta
 /// class of the Object. You can only add extension meta data at runtime to an unsealed dynamic meta
-/// class. See MetaClass on how to add a meta class of an object extension to the static meta class
+/// class. See MetaClass on how to add a meta-class of an object extension to the static meta-class
 /// of an Object.
 ///
-/// When you instantiate an Object through the meta class or through the Meta library factory, all
-/// the extensions added to the meta class will be instantiated and added to the instance.
+/// When you instantiate an Object through the meta-class or through the Meta library factory, all
+/// the extensions added to the meta-class will be instantiated and added to the instance.
 class META_API ObjectExtension : public MetaObject, public std::enable_shared_from_this<ObjectExtension>
 {
 public:

--- a/include/meta/object_extensions/object_extension.hpp
+++ b/include/meta/object_extensions/object_extension.hpp
@@ -30,15 +30,20 @@ namespace meta
 {
 
 /// The base class of object extensions. Object extensions dynamically extend an instance of an Object
-/// added functionality.
+/// with added functionality. To add an object extension to an Object, call Object::addExtension() method.
 ///
 /// When you add an object extension to an instance of an Object, the instance takes the ownership
 /// over the object extension. An object extension may only be attached to a single Object instance
 /// at a time. You can move an object extension from an Object instance to an other by removing the
 /// object extension from the source instance before adding it to the destination instance.
 ///
-/// You can add object extensions to a metaclass. When you instantiate an object through the meta class,
-/// all the extensions added to the meta class will be instantiated and added to the instance.
+/// You can add object extensions to a meta class of an Object by adding its meta class to the meta
+/// class of the Object. You can only add extension meta data at runtime to an unsealed dynamic meta
+/// class. See MetaClass on how to add a meta class of an object extension to the static meta class
+/// of an Object.
+///
+/// When you instantiate an Object through the meta class or through the Meta library factory, all
+/// the extensions added to the meta class will be instantiated and added to the instance.
 class META_API ObjectExtension : public MetaObject, public std::enable_shared_from_this<ObjectExtension>
 {
 public:

--- a/include/utils/utility.hpp
+++ b/include/utils/utility.hpp
@@ -28,7 +28,7 @@ namespace utils
 template <class Function, class... Arguments>
 void for_each_arg(Function f, Arguments&&... args)
 {
-    (void)(int[]){(f(std::forward<Arguments>(args)), 0)...};
+    (f(std::forward<Arguments>(args)),...);
 }
 
 }

--- a/include/utils/utility.hpp
+++ b/include/utils/utility.hpp
@@ -19,16 +19,14 @@
 #ifndef UTILS_UTILITY_HPP
 #define UTILS_UTILITY_HPP
 
-#include <utility>
-
 namespace utils
 {
 
 /// Template function to call a function \a f on an argument pack.
 template <class Function, class... Arguments>
-void for_each_arg(Function f, Arguments&&... args)
+void for_each_arg(Function f, Arguments... args)
 {
-    (f(std::forward<Arguments>(args)),...);
+    (f(args),...);
 }
 
 }

--- a/include/utils/utility.hpp
+++ b/include/utils/utility.hpp
@@ -22,12 +22,16 @@
 namespace utils
 {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
+
 /// Template function to call a function \a f on an argument pack.
 template <class Function, class... Arguments>
 void for_each_arg(Function f, Arguments... args)
 {
     (f(args),...);
 }
+#pragma GCC diagnostic pop
 
 }
 

--- a/src/metadata/factory.cpp
+++ b/src/metadata/factory.cpp
@@ -30,12 +30,12 @@ bool ObjectFactory::registerMetaClass(const MetaClass* metaClass)
     abortIfFail(metaClass);
     if (metaClass->getName().empty())
     {
-        META_LOG_ERROR("Attempt registering stub meta class.");
+        META_LOG_ERROR("Attempt registering stub meta-class.");
         return false;
     }
     if (!isValidMetaName(metaClass->getName()))
     {
-        META_LOG_ERROR("Invalid meta class name: " << metaClass->getName());
+        META_LOG_ERROR("Invalid meta-class name: " << metaClass->getName());
         return false;
     }
 
@@ -75,7 +75,7 @@ const MetaClass* ObjectFactory::findMetaClass(std::string_view className) const
 {
     if (!isValidMetaName(className))
     {
-        META_LOG_ERROR("Invalid meta class name: " << className);
+        META_LOG_ERROR("Invalid meta-class name: " << className);
         return {};
     }
     auto it = m_registry.find(className);

--- a/src/metadata/factory.cpp
+++ b/src/metadata/factory.cpp
@@ -80,45 +80,13 @@ bool ObjectFactory::registerMetaClass(const MetaClass* metaClass)
     return result.second;
 }
 
-bool ObjectFactory::registerMetaClass(std::string_view name, const MetaClass* metaClass)
+bool ObjectFactory::overrideMetaClass(const MetaClass* metaClass)
 {
     abortIfFail(metaClass);
-
-    if (!isValidMetaName(name))
-    {
-        META_LOG_ERROR("Invalid meta class name: " << metaClass->getName());
-        return false;
-    }
-
-    if (findMetaClass(name))
-    {
-        META_LOG_ERROR("Meta class with name found: " << name);
-        return false;
-    }
-
-    auto result = m_registry.insert(std::make_pair(name, metaClass));
-    ObjectFactoryPrivate::deepRegister(*this, metaClass);
-    if (result.second)
-    {
-        metaClass->m_descriptor->name = name;
-    }
-    return result.second;
-}
-
-
-bool ObjectFactory::overrideMetaClass(std::string_view name, const MetaClass* metaClass)
-{
-    abortIfFail(metaClass);
-    if (!isValidMetaName(name))
-    {
-        META_LOG_ERROR("Invalid meta class name: " << name);
-        return false;
-    }
-    auto it = m_registry.find(name);
+    auto it = m_registry.find(metaClass->getName());
     if (it != m_registry.end())
     {
         it->second = metaClass;
-        metaClass->m_descriptor->name = name;
         ObjectFactoryPrivate::deepOverride(*this, metaClass);
         return true;
     }

--- a/src/metadata/factory.cpp
+++ b/src/metadata/factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 bitWelder
+ * Copyright (C) 2024 bitWelder
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -20,6 +20,7 @@
 #include <meta/log/trace.hpp>
 #include <meta/metadata/factory.hpp>
 #include <meta/metadata/metaclass.hpp>
+#include <meta/metadata/meta_object.hpp>
 
 namespace meta
 {
@@ -103,6 +104,16 @@ const MetaClass* ObjectFactory::findMetaClass(std::string_view className) const
     }
     auto it = m_registry.find(className);
     return it != m_registry.end() ? it->second : nullptr;
+}
+
+MetaObjectPtr ObjectFactory::create(std::string_view className, std::string_view instanceName)
+{
+    auto metaClass = findMetaClass(className);
+    if (!metaClass)
+    {
+        return {};
+    }
+    return metaClass->create(instanceName);
 }
 
 }

--- a/src/metadata/metaclass.cpp
+++ b/src/metadata/metaclass.cpp
@@ -37,16 +37,28 @@ MetaObject::~MetaObject()
 }
 
 
-MetaClass::MetaExtensionRegistrar::MetaExtensionRegistrar(MetaClass& self, const MetaClass& extensionMeta)
+Registrars::Extension::Extension(Registrars& self, const MetaClass* extension)
 {
-    utils::ScopeValue<bool> unlock(self.m_descriptor->sealed, false);
-    self.addMetaExtension(extensionMeta);
+    auto registrar = [extension](MetaClass& metaClass)
+    {
+        metaClass.addMetaExtension(*extension);
+    };
+    self.m_registrars.push_back(registrar);
 }
 
-MetaClass::MetaName::MetaName(MetaClass& self, std::string_view name)
+void Registrars::apply(MetaClass& metaClass)
 {
-    self.m_descriptor->name = ensureValidMetaName(std::string(name));
-    abortIfFail(isValidMetaName(self.m_descriptor->name));
+    for (auto& registrar : m_registrars)
+    {
+        registrar(metaClass);
+    }
+}
+
+
+MetaClass::MetaExtensionRegistrar::MetaExtensionRegistrar(MetaClass& self, const MetaClass& extensionMeta)
+{
+    // utils::ScopeValue<bool> unlock(self.m_descriptor->sealed, false);
+    self.addMetaExtension(extensionMeta);
 }
 
 

--- a/src/metadata/metaclass.cpp
+++ b/src/metadata/metaclass.cpp
@@ -36,13 +36,6 @@ MetaObject::~MetaObject()
 {
 }
 
-const MetaClass* MetaObject::getStaticMetaClass()
-{
-    static detail::MetaClassImpl<MetaObject> metaClass;
-    static MetaClass::MetaName name(metaClass, "meta.MetaObject");
-    return &metaClass;
-}
-
 
 MetaClass::MetaExtensionRegistrar::MetaExtensionRegistrar(MetaClass& self, const MetaClass& extensionMeta)
 {
@@ -57,6 +50,21 @@ MetaClass::MetaName::MetaName(MetaClass& self, std::string_view name)
 }
 
 
+MetaObjectPtr MetaClass::create(std::string_view name) const
+{
+    abortIfFail(m_descriptor);
+    auto object = m_descriptor->create(name);
+    if (object)
+    {
+        object->m_factory = const_cast<MetaClass*>(this);
+    }
+    auto extendable = std::dynamic_pointer_cast<Object>(object);
+    if (extendable)
+    {
+        initializeInstance(extendable);
+    }
+    return object;
+}
 
 void MetaClass::initializeInstance(ObjectPtr instance) const
 {

--- a/src/metadata/metaclass.cpp
+++ b/src/metadata/metaclass.cpp
@@ -41,7 +41,7 @@ Registrars::Extension::Extension(Registrars& self, const MetaClass* extension)
 {
     auto registrar = [extension](MetaClass& metaClass)
     {
-        metaClass.addMetaExtension(*extension);
+        metaClass.addMetaExtension(extension);
     };
     self.m_registrars.push_back(registrar);
 }
@@ -52,13 +52,6 @@ void Registrars::apply(MetaClass& metaClass)
     {
         registrar(metaClass);
     }
-}
-
-
-MetaClass::MetaExtensionRegistrar::MetaExtensionRegistrar(MetaClass& self, const MetaClass& extensionMeta)
-{
-    // utils::ScopeValue<bool> unlock(self.m_descriptor->sealed, false);
-    self.addMetaExtension(extensionMeta);
 }
 
 
@@ -80,11 +73,16 @@ MetaObjectPtr MetaClass::create(std::string_view name) const
 
 void MetaClass::initializeInstance(ObjectPtr instance) const
 {
-    for (auto& metaExtension : m_descriptor->extensions)
+    auto visitor = [instance](auto metaClass)
     {
-        auto extension = metaExtension.second->create<ObjectExtension>(metaExtension.second->getName());
-        instance->addExtension(extension);
-    }
+        for (auto& metaExtension : metaClass->m_descriptor->extensions)
+        {
+            auto extension = metaExtension.second->template create<ObjectExtension>(metaExtension.second->getName());
+            instance->addExtension(extension);
+        }
+        return VisitResult::Continue;
+    };
+    visit(visitor);
 }
 
 bool MetaClass::isSealed() const
@@ -99,47 +97,45 @@ std::string_view MetaClass::getName() const
     return m_descriptor->name;
 }
 
-const MetaClass* MetaClass::getBaseClass(std::size_t index) const
-{
-    abortIfFail(m_descriptor);
-    return m_descriptor->getBaseClass(index);
-}
-
-std::size_t MetaClass::getBaseClassCount() const
-{
-    abortIfFail(m_descriptor);
-    return m_descriptor->getBaseClassCount();
-}
-
 bool MetaClass::isAbstract() const
 {
     abortIfFail(m_descriptor);
     return m_descriptor->isAbstract();
 }
 
-bool MetaClass::isMetaClassOf(const MetaObject& object) const
-{
-    abortIfFail(m_descriptor);
-    return m_descriptor->isMetaClassOf(object);
-}
-
 bool MetaClass::isDerivedFrom(const MetaClass& metaClass) const
 {
     abortIfFail(m_descriptor);
-    if (&metaClass == this)
+
+    auto visitor = [&metaClass](auto super)
     {
-        return true;
-    }
-    return m_descriptor->hasSuperClass(metaClass);
+        return (super == &metaClass) ? VisitResult::Abort : VisitResult::Continue;
+    };
+    return visitSuper(visitor) == VisitResult::Abort;
 }
 
-void MetaClass::addMetaExtension(const MetaClass& extensionMeta)
+MetaClass::VisitResult MetaClass::visit(Visitor visitor) const
 {
-    abortIfFail(m_descriptor && !m_descriptor->sealed && extensionMeta.m_descriptor && extensionMeta.m_descriptor->isExtension());
+    auto result = visitor(this);
+    if (result == VisitResult::Abort)
+    {
+        return result;
+    }
+    return visitSuper(visitor);
+}
+
+MetaClass::VisitResult MetaClass::visitSuper(Visitor visitor) const
+{
+    return m_descriptor->visitSuper(visitor);
+}
+
+void MetaClass::addMetaExtension(const MetaClass* extensionMeta)
+{
+    abortIfFail(m_descriptor && extensionMeta && !m_descriptor->sealed && extensionMeta->m_descriptor && extensionMeta->m_descriptor->isExtension());
 
     // The metaExtension must have a name.
-    abortIfFail(!extensionMeta.getName().empty());
-    auto result = m_descriptor->extensions.insert({extensionMeta.getName(), &extensionMeta});
+    abortIfFail(!extensionMeta->getName().empty());
+    auto result = m_descriptor->extensions.insert({extensionMeta->getName(), extensionMeta});
     abortIfFail(result.second);
 }
 
@@ -164,8 +160,31 @@ bool MetaClass::tryAddExtension(std::string_view metaName)
 const MetaClass* MetaClass::findMetaExtension(std::string_view name) const
 {
     abortIfFail(isValidMetaName(name) && m_descriptor);
-    auto it = m_descriptor->extensions.find(name);
-    return it != m_descriptor->extensions.end() ? it->second : nullptr;
+
+    const MetaClass* result = nullptr;
+    auto visitor = [&result, name](auto metaClass)
+    {
+        auto it = metaClass->m_descriptor->extensions.find(name);
+        if (it != metaClass->m_descriptor->extensions.end())
+        {
+            result = it->second;
+            return VisitResult::Abort;
+        }
+        return VisitResult::Continue;
+    };
+    visit(visitor);
+
+    return result;
+}
+
+MetaClass::MetaExtensionIterator MetaClass::beginExtensions() const
+{
+    return m_descriptor->extensions.begin();
+}
+
+MetaClass::MetaExtensionIterator MetaClass::endExtensions() const
+{
+    return m_descriptor->extensions.end();
 }
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -46,11 +46,9 @@ ObjectPtr Object::create(std::string_view name)
 
 void Object::addExtension(ObjectExtensionPtr extension)
 {
-    abortIfFail(!extension->getObject());
-
     if (extension->getObject().get() == this)
     {
-        META_LOG_ERROR("Extension " << extension->getName() <<" already extends the object.");
+        META_LOG_ERROR("Extension '" << extension->getName() <<"' already extends the object.");
         return;
     }
 
@@ -59,7 +57,6 @@ void Object::addExtension(ObjectExtensionPtr extension)
     {
         extension->attachToObject(*this);
     }
-    // return it.second;
 }
 
 bool Object::removeExtension(ObjectExtension& extension)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -32,10 +32,16 @@ Object::~Object()
 {
 }
 
+void Object::initialize()
+{
+    MetaObject::initialize();
+}
 
 ObjectPtr Object::create(std::string_view name)
 {
-    return ObjectPtr(new Object(name));
+    auto object = ObjectPtr(new Object(name));
+    object->initialize();
+    return object;
 }
 
 void Object::addExtension(ObjectExtensionPtr extension)

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -39,6 +39,13 @@
 namespace meta
 {
 
+namespace
+{
+
+const std::string_view c_invalidMetaNameCharacters{"~`!@#$%^&*()+={[}]|\\;\"'<,>?/ "};
+
+}
+
 class MetaLibraryPrivate
 {
 public:
@@ -135,7 +142,23 @@ ObjectFactory* Library::objectFactory() const
 
 bool isValidMetaName(std::string_view name)
 {
-    return !name.empty() && name.find_first_of("~`!@#$%^&*()+={[}]|\\;\"'<,>?/ ") == std::string_view::npos;
+    return !name.empty() && name.find_first_of(c_invalidMetaNameCharacters) == std::string_view::npos;
 }
+
+std::string ensureValidMetaName(std::string name, char hint)
+{
+    abortIfFail(!name.empty());
+
+    auto hintIt = c_invalidMetaNameCharacters.find_first_of(hint);
+    abortIfFail(hintIt == std::string_view::npos);
+
+    std::size_t it = 0;
+    while ( (it = name.find_first_of(c_invalidMetaNameCharacters)) != std::string::npos)
+    {
+        name.at(it) = hint;
+    }
+    return name;
+}
+
 
 }

--- a/tests/files.cmake
+++ b/tests/files.cmake
@@ -8,6 +8,7 @@ test_object.cpp
 test_object_extension.cpp
 test_thread_pool.cpp
 test_log_fixtures.hpp
+test_meta_class_fixtures.hpp
 test_utils.hpp
 utils/domain_test_environment.hpp
 utils/trace_printer_mock.hpp

--- a/tests/test_meta_class.cpp
+++ b/tests/test_meta_class.cpp
@@ -19,147 +19,196 @@
 #include <gtest/gtest.h>
 
 #include "test_meta_class_fixtures.hpp"
-#include "utils/domain_test_environment.hpp"
 
 namespace
 {
 
-class ObjectFactoryTest : public DomainTestEnvironment
+// {TMetaClass, bool-value}
+template <typename TClass, bool value>
+struct BoolParam
 {
-protected:
-    meta::ObjectFactory* m_factory = nullptr;
-    std::size_t m_registrySize = 0u;
-
-    void SetUp() override
-    {
-        initializeDomain(false, true);
-        m_factory = meta::Library::instance().objectFactory();
-        m_registrySize = std::distance(m_factory->begin(), m_factory->end());
-    }
+    const meta::MetaClass* metaClass = TClass::getStaticMetaClass();
+    bool test = value;
 };
 
-using MetaNameParam = std::tuple<std::string, bool>;
-class MetaNameValidityTest : public ::testing::Test, public ::testing::WithParamInterface<MetaNameParam>
+template <typename TBaseClass, typename TDerivedClass, bool Result>
+struct TwoTypesRelationTest
 {
-protected:
-    std::string metaClassName;
-    bool isValid;
+    using BaseClass = TBaseClass;
+    using DerivedClass = TDerivedClass;
 
-    void SetUp() override
-    {
-        auto args = GetParam();
-        metaClassName = std::get<std::string>(args);
-        isValid = std::get<bool>(args);
-    }
+    const meta::MetaClass* baseClass = TBaseClass::getStaticMetaClass();
+    const meta::MetaClass* derivedClass = TDerivedClass::getStaticMetaClass();
+    bool test = Result;
 };
 
-class MetaLibraryTest : public DomainTestEnvironment
-{
-protected:
-    void SetUp() override
-    {
-        DomainTestEnvironment::initializeDomain(true, true);
-    }
-};
+
+template <typename Traits>
+using MetaClassTestsGetStaticMetaClass = TypedMetaClassTests<Traits>;
+
+using GetNameParam = MetaClassParam<std::string_view>;
+using MetaClass_GetName = BaseParamMetaClassTest<std::string_view, MetaClassTests>;
+
+using FindExtensionParam = MetaClassParam<std::vector<std::string_view>>;
+using MetaClass_FindExtension = BaseParamMetaClassTest<std::vector<std::string_view>, MetaClassTests>;
+
+template <typename Traits>
+using MetaClassTestsIsAbstractMetaClass = BaseTypedMetaClassTests<Traits>;
+
+template <typename Traits>
+using MetaClassTestsIsDerivedFrom = BaseTypedMetaClassTests<Traits>;
 
 }
 
-TEST(MetaData, size)
-{
-    std::cerr << "MetaExtensionRegistrar size= " << sizeof(meta::MetaClass::MetaExtensionRegistrar) << std::endl;
-    std::cerr << "ExtendedObject::StaticMetaClass size= " << sizeof(*ExtendedObject::getStaticMetaClass()) << std::endl;
-}
-
-TEST(MetaClassTests, testMetaObject)
-{
-    ASSERT_NE(nullptr, meta::MetaObject::getStaticMetaClass());
-    EXPECT_FALSE(meta::MetaObject::getStaticMetaClass()->isAbstract());
-    EXPECT_EQ(0u, meta::MetaObject::getStaticMetaClass()->getBaseClassCount());
-}
-
-TEST(MetaClassTests, testAbstractMetaClass)
-{
-    ASSERT_NE(nullptr, AbstractClass::getStaticMetaClass());
-    EXPECT_TRUE(AbstractClass::getStaticMetaClass()->isAbstract());
-    ASSERT_EQ(1u, AbstractClass::getStaticMetaClass()->getBaseClassCount());
-    EXPECT_TRUE(AbstractClass::getStaticMetaClass()->isDerivedFromClass<meta::Object>());
-    EXPECT_FALSE(AbstractClass::getStaticMetaClass()->isDerivedFromClass<AbstractClass>());
-    EXPECT_TRUE(AbstractClass::getStaticMetaClass()->isDerivedFrom(*meta::Object::getStaticMetaClass()));
-    EXPECT_TRUE(AbstractClass::getStaticMetaClass()->isDerivedFrom(*AbstractClass::getStaticMetaClass()));
-}
-
-TEST(MetaClassTests, testInterface)
-{
-    ASSERT_NE(nullptr, Interface::getStaticMetaClass());
-    EXPECT_TRUE(Interface::getStaticMetaClass()->isAbstract());
-    ASSERT_EQ(0u, Interface::getStaticMetaClass()->getBaseClassCount());
-}
-
-TEST(MetaClassTests, testObject)
-{
-    ASSERT_NE(nullptr, Object::getStaticMetaClass());
-    EXPECT_FALSE(Object::getStaticMetaClass()->isAbstract());
-    ASSERT_EQ(2u, Object::getStaticMetaClass()->getBaseClassCount());
-    EXPECT_TRUE(Object::getStaticMetaClass()->isDerivedFromClass<meta::Object>());
-    EXPECT_TRUE(Object::getStaticMetaClass()->isDerivedFromClass<AbstractClass>());
-    EXPECT_TRUE(Object::getStaticMetaClass()->isDerivedFromClass<Interface>());
-
-    EXPECT_TRUE(Object::getStaticMetaClass()->isDerivedFrom(*meta::Object::getStaticMetaClass()));
-    EXPECT_TRUE(Object::getStaticMetaClass()->isDerivedFrom(*AbstractClass::getStaticMetaClass()));
-    EXPECT_TRUE(Object::getStaticMetaClass()->isDerivedFrom(*Interface::getStaticMetaClass()));
-}
-
-INSTANTIATE_TEST_SUITE_P(NameValidity, MetaNameValidityTest,
+INSTANTIATE_TEST_SUITE_P(MetaClassTests, MetaNameValidityTest,
                          ::testing::Values(
-                            MetaNameParam("meta.Object", true),
-                            MetaNameParam("meta:Object", true),
-                            MetaNameParam("meta-Object", true),
-                            MetaNameParam("meta_Object", true),
-                            MetaNameParam("meta~Object", false),
-                            MetaNameParam("meta`Object", false),
-                            MetaNameParam("meta!Object", false),
-                            MetaNameParam("meta@Object", false),
-                            MetaNameParam("meta#Object", false),
-                            MetaNameParam("meta$Object", false),
-                            MetaNameParam("meta$Object", false),
-                            MetaNameParam("meta%Object", false),
-                            MetaNameParam("meta^Object", false),
-                            MetaNameParam("meta&Object", false),
-                            MetaNameParam("meta*Object", false),
-                            MetaNameParam("meta(Object", false),
-                            MetaNameParam("meta)Object", false),
-                            MetaNameParam("meta+Object", false),
-                            MetaNameParam("meta=Object", false),
-                            MetaNameParam("meta{Object", false),
-                            MetaNameParam("meta[Object", false),
-                            MetaNameParam("meta}Object", false),
-                            MetaNameParam("meta]Object", false),
-                            MetaNameParam("meta|Object", false),
-                            MetaNameParam("meta\\Object", false),
-                            MetaNameParam("meta;Object", false),
-                            MetaNameParam("meta\"Object", false),
-                            MetaNameParam("meta'Object", false),
-                            MetaNameParam("meta<Object", false),
-                            MetaNameParam("meta,Object", false),
-                            MetaNameParam("meta>Object", false),
-                            MetaNameParam("meta?Object", false),
-                            MetaNameParam("meta/Object", false),
-                            MetaNameParam("meta Object", false)));
+                             MetaNameParam("meta.Object", true),
+                             MetaNameParam("meta:Object", true),
+                             MetaNameParam("meta-Object", true),
+                             MetaNameParam("meta_Object", true),
+                             MetaNameParam("meta~Object", false),
+                             MetaNameParam("meta`Object", false),
+                             MetaNameParam("meta!Object", false),
+                             MetaNameParam("meta@Object", false),
+                             MetaNameParam("meta#Object", false),
+                             MetaNameParam("meta$Object", false),
+                             MetaNameParam("meta$Object", false),
+                             MetaNameParam("meta%Object", false),
+                             MetaNameParam("meta^Object", false),
+                             MetaNameParam("meta&Object", false),
+                             MetaNameParam("meta*Object", false),
+                             MetaNameParam("meta(Object", false),
+                             MetaNameParam("meta)Object", false),
+                             MetaNameParam("meta+Object", false),
+                             MetaNameParam("meta=Object", false),
+                             MetaNameParam("meta{Object", false),
+                             MetaNameParam("meta[Object", false),
+                             MetaNameParam("meta}Object", false),
+                             MetaNameParam("meta]Object", false),
+                             MetaNameParam("meta|Object", false),
+                             MetaNameParam("meta\\Object", false),
+                             MetaNameParam("meta;Object", false),
+                             MetaNameParam("meta\"Object", false),
+                             MetaNameParam("meta'Object", false),
+                             MetaNameParam("meta<Object", false),
+                             MetaNameParam("meta,Object", false),
+                             MetaNameParam("meta>Object", false),
+                             MetaNameParam("meta?Object", false),
+                             MetaNameParam("meta/Object", false),
+                             MetaNameParam("meta Object", false)));
 TEST_P(MetaNameValidityTest, testMetaClassName)
 {
     EXPECT_EQ(isValid, meta::isValidMetaName(this->metaClassName));
 }
 
-TEST_F(ObjectFactoryTest, testRegister)
+
+using GetStaticMetaClassTypes = ::testing::Types<meta::MetaObject,
+                                                 meta::Object,
+                                                 meta::ObjectExtension,
+                                                 AbstractClass,
+                                                 Interface,
+                                                 OverrideClass,
+                                                 PreObject,
+                                                 Object,
+                                                 ExtendedObject,
+                                                 DynamicObject,
+                                                 ExtendObjectFunction,
+                                                 LambdaInvokable>;
+TYPED_TEST_SUITE(MetaClassTestsGetStaticMetaClass, GetStaticMetaClassTypes);
+TYPED_TEST(MetaClassTestsGetStaticMetaClass, getStaticMetaClass)
 {
-    EXPECT_TRUE(m_factory->registerMetaClass(Object::getStaticMetaClass()));
-    EXPECT_FALSE(m_factory->registerMetaClass(Object::getStaticMetaClass()));
+    using MetaClassType = TestFixture::Traits;
+    auto metaClass = MetaClassType::getStaticMetaClass();
+    ASSERT_NE(nullptr, metaClass);
+}
+TYPED_TEST(MetaClassTestsGetStaticMetaClass, isSealed)
+{
+    using MetaClassType = TestFixture::Traits;
+    auto metaClass = MetaClassType::getStaticMetaClass();
+    EXPECT_TRUE(metaClass->isSealed());
+}
+TYPED_TEST(MetaClassTestsGetStaticMetaClass, registerMetaClass)
+{
+    meta::ObjectFactory factory;
+    using MetaClassType = TestFixture::Traits;
+    auto metaClass = MetaClassType::getStaticMetaClass();
+
+    EXPECT_TRUE(factory.registerMetaClass(metaClass));
+    EXPECT_FALSE(factory.registerMetaClass(metaClass));
+}
+TYPED_TEST(MetaClassTestsGetStaticMetaClass, registerMetaClassWithTemplate)
+{
+    meta::ObjectFactory factory;
+    using MetaClassType = TestFixture::Traits;
+
+    EXPECT_TRUE(factory.registerMetaClass<MetaClassType>());
+    EXPECT_FALSE(factory.registerMetaClass<MetaClassType>());
 }
 
-TEST_F(ObjectFactoryTest, registerObjectExtension)
+INSTANTIATE_TEST_SUITE_P(MetaClassTests, MetaClass_GetName,
+                         ::testing::Values(
+                             GetNameParam{meta::MetaObject::getStaticMetaClass(), "meta.MetaObject"},
+                             GetNameParam{meta::Object::getStaticMetaClass(), "meta.Object"},
+                             GetNameParam{AbstractClass::getStaticMetaClass(), "AbstractClass"},
+                             GetNameParam{Interface::getStaticMetaClass(), "Interface"},
+                             GetNameParam{OverrideClass::getStaticMetaClass(), "AbstractClass"},
+                             GetNameParam{PreObject::getStaticMetaClass(), "PreObject"},
+                             GetNameParam{Object::getStaticMetaClass(), "TestObject"},
+                             GetNameParam{ExtendedObject::getStaticMetaClass(), "ExtendedObject"},
+                             GetNameParam{DynamicObject::getStaticMetaClass(), "DynamicObject"},
+                             GetNameParam{ExtendObjectFunction::getStaticMetaClass(), "extendObjects"},
+                             GetNameParam{LambdaInvokable::getStaticMetaClass(), "lambda"}));
+TEST_P(MetaClass_GetName, metaClass_getName)
 {
-    EXPECT_TRUE(m_factory->registerMetaClass<LambdaInvokable>());
+    EXPECT_EQ(this->param.param, this->param.metaClass->getName());
 }
+
+using IsAbstractMetaClassTypes = ::testing::Types<BoolParam<meta::MetaObject, false>,
+                                                  BoolParam<meta::Object, false>,
+                                                  BoolParam<Interface, true>,
+                                                  BoolParam<AbstractClass, true>,
+                                                  BoolParam<Object, false>>;
+TYPED_TEST_SUITE(MetaClassTestsIsAbstractMetaClass, IsAbstractMetaClassTypes);
+TYPED_TEST(MetaClassTestsIsAbstractMetaClass, staticMetaClass_isAbstract)
+{
+    EXPECT_EQ(this->traits.test, this->traits.metaClass->isAbstract());
+}
+
+using IsDerivedFromTypes = ::testing::Types<TwoTypesRelationTest<meta::MetaObject, meta::MetaObject, false>,
+                                            TwoTypesRelationTest<meta::Object, meta::MetaObject, false>,
+                                            TwoTypesRelationTest<meta::MetaObject, meta::Object, true>,
+                                            TwoTypesRelationTest<meta::MetaObject, Object, true>,
+                                            TwoTypesRelationTest<Interface, AbstractClass, false>,
+                                            TwoTypesRelationTest<meta::MetaObject, AbstractClass, true>,
+                                            TwoTypesRelationTest<Interface, Object, true>>;
+TYPED_TEST_SUITE(MetaClassTestsIsDerivedFrom, IsDerivedFromTypes);
+TYPED_TEST(MetaClassTestsIsDerivedFrom, staticMetaClass_isDerivedFrom)
+{
+    using BaseClass = TestFixture::Traits::BaseClass;
+    EXPECT_EQ(this->traits.test, this->traits.derivedClass->isDerivedFrom(*this->traits.baseClass));
+    EXPECT_EQ(this->traits.test, this->traits.derivedClass->template isDerivedFromClass<BaseClass>());
+}
+
+INSTANTIATE_TEST_SUITE_P(MetaClassTests, MetaClass_FindExtension,
+                         ::testing::Values(
+                             FindExtensionParam{meta::MetaObject::getStaticMetaClass(), {}},
+                             FindExtensionParam{meta::Object::getStaticMetaClass(), {}},
+                             FindExtensionParam{AbstractClass::getStaticMetaClass(), {}},
+                             FindExtensionParam{Interface::getStaticMetaClass(), {}},
+                             FindExtensionParam{OverrideClass::getStaticMetaClass(), {}},
+                             FindExtensionParam{PreObject::getStaticMetaClass(), {}},
+                             FindExtensionParam{Object::getStaticMetaClass(), {}},
+                             FindExtensionParam{ExtendedObject::getStaticMetaClass(), {"getName"}},
+                             FindExtensionParam{DynamicObject::getStaticMetaClass(), {"getName"}}));
+TEST_P(MetaClass_FindExtension, findMetaExtension)
+{
+    for (auto& extensionName : this->param.param)
+    {
+        auto extension = this->param.metaClass->findMetaExtension(extensionName);
+        EXPECT_NE(nullptr, extension);
+    }
+}
+
 
 TEST_F(ObjectFactoryTest, deepRegister)
 {
@@ -172,27 +221,28 @@ TEST_F(ObjectFactoryTest, deepRegister)
     EXPECT_NE(nullptr, m_factory->findMetaClass("meta.Object"));
 }
 
-TEST_F(ObjectFactoryTest, registerStubMetaClassTheRightWay)
+TEST_F(ObjectFactoryTest, registerAutoMetaClass)
 {
     auto lambda = [](){};
-    using StubType = meta::Invokable<decltype(lambda), lambda>;
-    m_factory->registerMetaClass(StubType::getStaticMetaClass());
+    using AutoType = meta::Invokable<decltype(lambda), lambda>;
+    m_factory->registerMetaClass(AutoType::getStaticMetaClass());
     EXPECT_EQ(m_registrySize + 1u, std::distance(m_factory->begin(), m_factory->end()));
-    EXPECT_NE(nullptr, m_factory->findMetaClass(StubType::getStaticMetaClass()->getName()));
+    EXPECT_NE(nullptr, m_factory->findMetaClass(AutoType::getStaticMetaClass()->getName()));
 }
 
-TEST_F(ObjectFactoryTest, testOverride)
+TEST_F(ObjectFactoryTest, registerOverride)
 {
     EXPECT_TRUE(m_factory->registerMetaClass(AbstractClass::getStaticMetaClass()));
     EXPECT_TRUE(m_factory->overrideMetaClass(OverrideClass::getStaticMetaClass()));
 }
 
-TEST_F(ObjectFactoryTest, deepOverride)
+TEST_F(ObjectFactoryTest, deepRegisterOverride)
 {
     EXPECT_TRUE(m_factory->registerMetaClass(AbstractClass::getStaticMetaClass()));
     EXPECT_EQ(m_registrySize + 1u, std::distance(m_factory->begin(), m_factory->end()));
     EXPECT_NE(nullptr, m_factory->findMetaClass("AbstractClass"));
     EXPECT_NE(nullptr, m_factory->findMetaClass("meta.Object"));
+    EXPECT_EQ(nullptr, m_factory->findMetaClass("Interface"));
 
     EXPECT_TRUE(m_factory->overrideMetaClass(OverrideClass::getStaticMetaClass()));
     EXPECT_EQ(m_registrySize + 2u, std::distance(m_factory->begin(), m_factory->end()));
@@ -212,39 +262,30 @@ TEST_F(ObjectFactoryTest, registerDynamicMetaclass)
     EXPECT_NE(nullptr, m_factory->findMetaClass("DynamicObject"));
 }
 
-TEST_F(ObjectFactoryTest, testFindMetaClass)
+TEST_F(ObjectFactoryTest, findMetaClass)
 {
-    EXPECT_TRUE(m_factory->registerMetaClass(AbstractClass::getStaticMetaClass()));
-    EXPECT_TRUE(m_factory->registerMetaClass(Interface::getStaticMetaClass()));
-    EXPECT_TRUE(m_factory->registerMetaClass(Object::getStaticMetaClass()));
+    registerTestClasses();
 
     EXPECT_EQ(Interface::getStaticMetaClass(), m_factory->findMetaClass("Interface"));
 }
 
-TEST_F(ObjectFactoryTest, testMetaClassCreate)
+TEST_F(ObjectFactoryTest, create)
 {
-    m_factory->registerMetaClass(Object::getStaticMetaClass());
+    registerTestClasses();
 
-    auto metaClass = m_factory->findMetaClass(Object::getStaticMetaClass()->getName());
-    ASSERT_EQ(Object::getStaticMetaClass(), metaClass);
-    ASSERT_NE(nullptr, metaClass->create("doing"));
-    auto castedObject = metaClass->create<Object>("next");
-    ASSERT_NE(nullptr, castedObject);
+    ASSERT_NE(nullptr, m_factory->create("TestObject", "doing"));
 }
 
-TEST_F(ObjectFactoryTest, testMetaClassCastedCreate)
+TEST_F(ObjectFactoryTest, create_template)
 {
-    m_factory->registerMetaClass(Object::getStaticMetaClass());
-    auto metaClass = m_factory->findMetaClass(Object::getStaticMetaClass()->getName());
-    ASSERT_NE(nullptr, metaClass);
-    auto castedObject = metaClass->create<Object>("next");
-    EXPECT_NE(nullptr, castedObject);
+    registerTestClasses();
+
+    ASSERT_NE(nullptr, m_factory->create<Object>("doing"));
 }
 
-TEST_F(ObjectFactoryTest, staticMetaExtension)
+TEST_F(ObjectFactoryTest, createWithMetaExtension)
 {    
-    ASSERT_TRUE(ExtendedObject::getStaticMetaClass()->isSealed());
-    m_factory->registerMetaClass(ExtendedObject::getStaticMetaClass());
+    registerTestClasses();
 
     auto object = m_factory->create<ExtendedObject>("test");
     ASSERT_NE(nullptr, object);
@@ -254,103 +295,44 @@ TEST_F(ObjectFactoryTest, staticMetaExtension)
     EXPECT_EQ("test", std::string_view(*result));
 }
 
-TEST_F(ObjectFactoryTest, dynamicMetaExtension)
+TEST_F(ObjectFactoryTest, createWithMetaExtensionInSuper)
 {
-    m_factory->registerMetaClass(DynamicObject::getStaticMetaClass());
-    m_factory->registerMetaClass(DynamicObject::getExtendableMetaClass());
+    registerTestClasses();
+
+    auto object = m_factory->create<DynamicObject>("test");
+    ASSERT_NE(nullptr, object);
+
+    auto result = object->invoke("getName");
+    ASSERT_TRUE(result);
+    EXPECT_EQ("test", std::string_view(*result));
+}
+
+TEST_F(ObjectFactoryTest, addDynamicMetaExtensionToMetaClass)
+{
+    registerTestClasses();
 
     auto dynamic = DynamicObject::getExtendableMetaClass();
     ASSERT_NE(nullptr, dynamic);
     EXPECT_FALSE(dynamic->isSealed());
 
-    auto lambda = [](DynamicObject* self)
-    {
-        META_LOG_INFO(self->getName());
-    };
-    using MetaLambda = meta::Invokable<decltype(lambda), lambda>;
-    dynamic->addMetaExtension(*MetaLambda::getStaticMetaClass());
-    EXPECT_NE(nullptr, dynamic->findMetaExtension(MetaLambda::getStaticMetaClass()->getName()));
+    dynamic->addMetaExtension(LambdaInvokable::getStaticMetaClass());
+    EXPECT_NE(nullptr, dynamic->findMetaExtension("lambda"));
+    EXPECT_NE(nullptr, dynamic->findMetaExtension("getName"));
 }
 
-TEST_F(ObjectFactoryTest, dynamicExtensions)
+
+TEST_F(MetaLibraryTest, metaLibrarysHasObjectFactory)
 {
-    auto dynamic = DynamicObject::getExtendableMetaClass();
-
-    auto lambda = [](meta::ObjectExtension* self)
-    {
-        META_LOG_INFO(self->getObject()->getName());
-    };
-    using MetaLambda = meta::Invokable<decltype(lambda), lambda>;
-    dynamic->addMetaExtension(*MetaLambda::getStaticMetaClass());
-
-    auto dynObject = dynamic->create<DynamicObject>("dynObject");
-    ASSERT_NE(nullptr, dynObject);
-
-    EXPECT_CALL(*m_mockPrinter, log("dynObject"));
-    dynObject->invoke(MetaLambda::getStaticMetaClass()->getName());
+    auto factory = meta::Library::instance().objectFactory();
+    EXPECT_NE(nullptr, factory);
 }
 
-TEST_F(ObjectFactoryTest, addRegisteredExtensionToDynamicMetaClass)
+TEST_F(MetaLibraryTest, metaLibraryObjectFactoryRegistryDefaultContent)
 {
-    ASSERT_TRUE(m_factory->registerMetaClass(ExtendObjectFunction::getStaticMetaClass()));
-    auto dynamic = DynamicObject::getExtendableMetaClass();
-    ASSERT_NE(nullptr, dynamic);
+    auto factory = meta::Library::instance().objectFactory();
+    EXPECT_EQ(3u, std::distance(factory->begin(), factory->end()));
 
-    ASSERT_TRUE(dynamic->tryAddExtension("extendObjects"));
-    auto object = dynamic->create<DynamicObject>("test");
-
-    EXPECT_CALL(*m_mockPrinter, log("extends test"));
-    meta::invoke(object, "extendObjects");
-}
-
-TEST_F(ObjectFactoryTest, createThroughMetaClassAddsExtensionsFromAllLevels)
-{
-    m_factory->registerMetaClass<DynamicObject>();
-    m_factory->registerMetaClass(DynamicObject::getExtendableMetaClass());
-
-    // This creates an object using the sealed meta class.
-    auto sealed = m_factory->create<DynamicObject>("DynamicObject", "sealed");
-    ASSERT_NE(nullptr, sealed);
-    EXPECT_TRUE(sealed->getDynamicMetaClass()->isSealed());
-
-    auto unsealed = m_factory->create<DynamicObject>("DynamicExtendedObject", "unsealed");
-    ASSERT_NE(nullptr, unsealed);
-    EXPECT_FALSE(unsealed->getDynamicMetaClass()->isSealed());
-}
-
-TEST_F(ObjectFactoryTest, dynamicMetaClassCreatedInstancegetsMoreExtensions)
-{
-    m_factory->registerMetaClass<DynamicObject>();
-    m_factory->registerMetaClass(DynamicObject::getExtendableMetaClass());
-
-    auto unsealed = m_factory->create<DynamicObject>("DynamicExtendedObject", "unsealed");
-    EXPECT_NE(nullptr, unsealed->findExtension("getName"));
-}
-
-TEST_F(MetaLibraryTest, findMetaExtension)
-{
-    auto metaClass = ExtendedObject::getStaticMetaClass();
-    auto getName = metaClass->findMetaExtension("getName");
-    ASSERT_NE(nullptr, getName);
-}
-
-TEST_F(MetaLibraryTest, enumerateExtensions)
-{
-    auto metaClass = ExtendedObject::getStaticMetaClass();
-
-    for (auto it = metaClass->beginExtensions(), end = metaClass->endExtensions(); it != end; ++it)
-    {
-        META_LOG_INFO(it->second->getName());
-    }
-}
-
-TEST_F(MetaLibraryTest, testDomainHasObjectFactory)
-{
-    EXPECT_NE(nullptr, meta::Library::instance().objectFactory());
-}
-
-TEST_F(MetaLibraryTest, testDomainObjectFactoryRegistryContent)
-{
-    ASSERT_NE(nullptr, meta::Library::instance().objectFactory());
-    EXPECT_NE(nullptr, meta::Library::instance().objectFactory()->findMetaClass("meta.Object"));
+    EXPECT_NE(nullptr, factory->findMetaClass("meta.MetaObject"));
+    EXPECT_NE(nullptr, factory->findMetaClass("meta.Object"));
+    EXPECT_NE(nullptr, factory->findMetaClass("meta.ObjectExtension"));
 }

--- a/tests/test_meta_class.cpp
+++ b/tests/test_meta_class.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "test_meta_class_fixtures.hpp"
+#include "utils/domain_test_environment.hpp"
 
 namespace
 {

--- a/tests/test_meta_class.cpp
+++ b/tests/test_meta_class.cpp
@@ -117,20 +117,20 @@ using GetStaticMetaClassTypes = ::testing::Types<meta::MetaObject,
 TYPED_TEST_SUITE(MetaClassTestsGetStaticMetaClass, GetStaticMetaClassTypes);
 TYPED_TEST(MetaClassTestsGetStaticMetaClass, getStaticMetaClass)
 {
-    using MetaClassType = TestFixture::Traits;
+    using MetaClassType = typename TestFixture::Traits;
     auto metaClass = MetaClassType::getStaticMetaClass();
     ASSERT_NE(nullptr, metaClass);
 }
 TYPED_TEST(MetaClassTestsGetStaticMetaClass, isSealed)
 {
-    using MetaClassType = TestFixture::Traits;
+    using MetaClassType = typename TestFixture::Traits;
     auto metaClass = MetaClassType::getStaticMetaClass();
     EXPECT_TRUE(metaClass->isSealed());
 }
 TYPED_TEST(MetaClassTestsGetStaticMetaClass, registerMetaClass)
 {
     meta::ObjectFactory factory;
-    using MetaClassType = TestFixture::Traits;
+    using MetaClassType = typename TestFixture::Traits;
     auto metaClass = MetaClassType::getStaticMetaClass();
 
     EXPECT_TRUE(factory.registerMetaClass(metaClass));
@@ -139,7 +139,7 @@ TYPED_TEST(MetaClassTestsGetStaticMetaClass, registerMetaClass)
 TYPED_TEST(MetaClassTestsGetStaticMetaClass, registerMetaClassWithTemplate)
 {
     meta::ObjectFactory factory;
-    using MetaClassType = TestFixture::Traits;
+    using MetaClassType = typename TestFixture::Traits;
 
     EXPECT_TRUE(factory.registerMetaClass<MetaClassType>());
     EXPECT_FALSE(factory.registerMetaClass<MetaClassType>());
@@ -184,7 +184,7 @@ using IsDerivedFromTypes = ::testing::Types<TwoTypesRelationTest<meta::MetaObjec
 TYPED_TEST_SUITE(MetaClassTestsIsDerivedFrom, IsDerivedFromTypes);
 TYPED_TEST(MetaClassTestsIsDerivedFrom, staticMetaClass_isDerivedFrom)
 {
-    using BaseClass = TestFixture::Traits::BaseClass;
+    using BaseClass = typename TestFixture::Traits::BaseClass;
     EXPECT_EQ(this->traits.test, this->traits.derivedClass->isDerivedFrom(*this->traits.baseClass));
     EXPECT_EQ(this->traits.test, this->traits.derivedClass->template isDerivedFromClass<BaseClass>());
 }

--- a/tests/test_meta_class.cpp
+++ b/tests/test_meta_class.cpp
@@ -320,6 +320,14 @@ TEST_F(ObjectFactoryTest, addDynamicMetaExtensionToMetaClass)
     EXPECT_NE(nullptr, dynamic->findMetaExtension("getName"));
 }
 
+TEST_F(ObjectFactoryTest, createWithoutFactoryIsMissingMetaExtensions)
+{
+    auto object = DynamicObject::create("test");
+
+    auto result = meta::invoke(object, "getName");
+    EXPECT_EQ(std::nullopt, result);
+}
+
 
 TEST_F(MetaLibraryTest, metaLibrarysHasObjectFactory)
 {

--- a/tests/test_meta_class_fixtures.hpp
+++ b/tests/test_meta_class_fixtures.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 bitWelder
+ * Copyright (C) 2023 bitWelder
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -24,12 +24,10 @@
 #include <meta/meta.hpp>
 #include <meta/metadata/factory.hpp>
 #include <meta/metadata/metaclass.hpp>
-#include <meta/object.hpp>
 #include <meta/library_config.hpp>
-
+#include <meta/object.hpp>
 #include <meta/object_extensions/invokable.hpp>
-
-#include "utils/domain_test_environment.hpp"
+#include <utils/scope_value.hpp>
 
 
 class AbstractClass : public meta::Object
@@ -116,6 +114,7 @@ protected:
     }
 };
 
+
 class ExtendedObject : public Object
 {
 public:
@@ -146,10 +145,9 @@ public:
 
     class DynamicExtendedObject : public DynamicObject::StaticMetaClass
     {
-        MetaName _name{*this, "DynamicExtendedObject"};
-
     public:
-        explicit DynamicExtendedObject()
+        explicit DynamicExtendedObject(std::string_view className) :
+            StaticMetaClass(className)
         {
             m_descriptor->sealed = false;
         }
@@ -166,7 +164,7 @@ public:
 
     static meta::MetaClass* getExtendableMetaClass()
     {
-        static DynamicExtendedObject dynamicClass;
+        static DynamicExtendedObject dynamicClass("DynamicExtendedObject");
         return &dynamicClass;
     }
 

--- a/tests/test_meta_class_fixtures.hpp
+++ b/tests/test_meta_class_fixtures.hpp
@@ -16,8 +16,8 @@
  * <http://www.gnu.org/licenses/>
  */
 
-#ifndef META_TEST_META_CLASS_FICXTURES_HPP
-#define META_TEST_META_CLASS_FICXTURES_HPP
+#ifndef META_TEST_META_CLASS_FIXTURES_HPP
+#define META_TEST_META_CLASS_FIXTURES_HPP
 
 #include <gtest/gtest.h>
 
@@ -230,7 +230,7 @@ protected:
 };
 
 
-// Base Test fixture with a meta class and a parameter with arbitrar type.
+// Base Test fixture with a meta-class and a parameter with arbitrar type.
 template <typename Param>
 struct MetaClassParam
 {
@@ -306,4 +306,4 @@ protected:
     }
 };
 
-#endif // META_TEST_META_CLASS_FICXTURES_HPP
+#endif // META_TEST_META_CLASS_FIXTURES_HPP

--- a/tests/test_meta_class_fixtures.hpp
+++ b/tests/test_meta_class_fixtures.hpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2024 bitWelder
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see
+ * <http://www.gnu.org/licenses/>
+ */
+
+#ifndef META_TEST_META_CLASS_FICXTURES_HPP
+#define META_TEST_META_CLASS_FICXTURES_HPP
+
+#include <gtest/gtest.h>
+
+#include <meta/meta.hpp>
+#include <meta/metadata/factory.hpp>
+#include <meta/metadata/metaclass.hpp>
+#include <meta/object.hpp>
+#include <meta/library_config.hpp>
+
+#include <meta/object_extensions/invokable.hpp>
+
+#include "utils/domain_test_environment.hpp"
+
+
+class AbstractClass : public meta::Object
+{
+public:
+    META_CLASS("AbstractClass", AbstractClass, meta::Object)
+    {
+    };
+
+    virtual void func() = 0;
+
+protected:
+    explicit AbstractClass(std::string_view name) :
+        meta::Object(name)
+    {
+    }
+};
+
+class Interface
+{
+public:
+    virtual ~Interface() = default;
+    virtual void text() = 0;
+
+    STATIC_META_CLASS("Interface", Interface)
+    {
+    };
+};
+
+class OverrideClass : public meta::Object, public Interface
+{
+public:
+    META_CLASS("AbstractClass", OverrideClass, meta::Object, Interface)
+    {
+    };
+
+    virtual void func() = 0;
+
+protected:
+    explicit OverrideClass(std::string_view name) :
+        meta::Object(name)
+    {
+    }
+};
+
+class PreObject : public AbstractClass
+{
+public:
+    META_CLASS("PreObject", PreObject, AbstractClass)
+    {
+    };
+    virtual void func3() = 0;
+
+protected:
+    explicit PreObject(std::string_view name) :
+        AbstractClass(name)
+    {
+    }
+};
+
+class Object : public PreObject, public Interface
+{
+public:
+    void func() override
+    {}
+    void text() override
+    {}
+    void func3() final
+    {}
+
+    META_CLASS("TestObject", Object, PreObject, Interface)
+    {
+    };
+
+    static std::shared_ptr<Object> create(std::string_view name)
+    {
+        return std::shared_ptr<Object>(new Object(name));
+    }
+
+protected:
+    explicit Object(std::string_view name) :
+        PreObject(name)
+    {
+    }
+};
+
+class ExtendedObject : public Object
+{
+public:
+    DECLARE_INVOKABLE(MetaGetName, "getName", &ExtendedObject::getName);
+    META_CLASS("ExtendedObject", ExtendedObject, Object)
+    {
+        META_EXTENSION(MetaGetName);
+    };
+
+    static std::shared_ptr<Object> create(std::string_view name)
+    {
+        return std::shared_ptr<Object>(new ExtendedObject(name));
+    }
+
+protected:
+    explicit ExtendedObject(std::string_view name) :
+        Object(name)
+    {
+    }
+};
+
+class DynamicObject : public ExtendedObject
+{
+public:
+    STATIC_META_CLASS("DynamicObject", DynamicObject, ExtendedObject)
+    {
+    };
+
+    class DynamicExtendedObject : public DynamicObject::StaticMetaClass
+    {
+        MetaName _name{*this, "DynamicExtendedObject"};
+
+    public:
+        explicit DynamicExtendedObject()
+        {
+            m_descriptor->sealed = false;
+        }
+    };
+    const meta::MetaClass* getDynamicMetaClass() const override
+    {
+        auto metaClass = getFactory();
+        if (!metaClass)
+        {
+            metaClass = getStaticMetaClass();
+        }
+        return metaClass;
+    }
+
+    static meta::MetaClass* getExtendableMetaClass()
+    {
+        static DynamicExtendedObject dynamicClass;
+        return &dynamicClass;
+    }
+
+    static auto create(std::string_view name)
+    {
+        return std::shared_ptr<Object>(new DynamicObject(name));
+    }
+
+protected:
+    explicit DynamicObject(std::string_view name) :
+        ExtendedObject(name)
+    {
+    }
+};
+
+void extendObjects(meta::ObjectExtension* self)
+{
+    META_LOG_INFO("extends " << self->getObject()->getName());
+}
+DECLARE_INVOKABLE(ExtendObjectFunction, "extendObjects", &extendObjects);
+
+auto globalLambda = [](){};
+DECLARE_INVOKABLE(LambdaInvokable, "lambda", globalLambda);
+
+#endif // META_TEST_META_CLASS_FICXTURES_HPP

--- a/tests/test_object.cpp
+++ b/tests/test_object.cpp
@@ -42,6 +42,11 @@ protected:
 
 }
 
+TEST_F(ObjectTest, createWithoutFactoryAddsMetaExtensions)
+{
+    auto object = meta::Object::create("test");
+
+}
 
 TEST_F(ObjectTest, invoke_getName)
 {

--- a/tests/test_object.cpp
+++ b/tests/test_object.cpp
@@ -42,11 +42,6 @@ protected:
 
 }
 
-TEST_F(ObjectTest, createWithoutFactoryAddsMetaExtensions)
-{
-    auto object = meta::Object::create("test");
-
-}
 
 TEST_F(ObjectTest, invoke_getName)
 {


### PR DESCRIPTION
- [x] tweak meta data
- [x] generate meta class name for Invokable<>
- [x] enable static meta class creation for non-MetaObject classes
- [x] meta data registrars
- [x] proper dynamic meta classes
- [x] expose meta class visiting
- [x] ability to do your own dynamic meta class override
- [x] enumerating meta extensions on a meta class to include extensions from all super meta classes - through visitors
- [x] better tests
